### PR TITLE
Scp/subtractions

### DIFF
--- a/ops/manifests/__init__.py
+++ b/ops/manifests/__init__.py
@@ -7,6 +7,7 @@ from .manipulations import (
     ManifestLabel,
     Patch,
     update_toleration,
+    SubtractEq,
 )
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "Manifests",
     "Patch",
     "update_toleration",
+    "SubtractEq",
 ]

--- a/ops/manifests/__init__.py
+++ b/ops/manifests/__init__.py
@@ -6,8 +6,8 @@ from .manipulations import (
     CreateNamespace,
     ManifestLabel,
     Patch,
-    update_toleration,
     SubtractEq,
+    update_toleration,
 )
 
 __all__ = [

--- a/ops/manifests/collector.py
+++ b/ops/manifests/collector.py
@@ -45,7 +45,7 @@ class Collector:
     def list_versions(self, event) -> None:
         """Respond to list_versions action."""
         result = {
-            f"{name} versions": "\n".join(str(_) for _ in manifest.releases)
+            f"{name}-versions": "\n".join(str(_) for _ in manifest.releases)
             for name, manifest in self.manifests.items()
         }
         event.set_results(result)

--- a/ops/manifests/collector.py
+++ b/ops/manifests/collector.py
@@ -5,7 +5,8 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Iterable, List, MutableMapping, Optional
 
-from ops.manifests.manifest import HashableResource, Manifests
+from .manifest import Manifests
+from .manipulations import HashableResource
 
 
 @dataclass

--- a/ops/manifests/collector.py
+++ b/ops/manifests/collector.py
@@ -128,9 +128,9 @@ class Collector:
             results[name] = _ResourceAnalysis(correct, extra, missing)
             event_result.update(
                 {
-                    f"{name} correct": "\n".join(sorted(str(_) for _ in correct)),
-                    f"{name} extra": "\n".join(sorted(str(_) for _ in extra)),
-                    f"{name} missing": "\n".join(sorted(str(_) for _ in missing)),
+                    f"{name}-correct": "\n".join(sorted(str(_) for _ in correct)),
+                    f"{name}-extra": "\n".join(sorted(str(_) for _ in extra)),
+                    f"{name}-missing": "\n".join(sorted(str(_) for _ in missing)),
                 }
             )
 

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -60,6 +60,7 @@ class Manifests:
     def __init__(
         self,
         name: str,
+        model_name: str,
         app_name: str,
         base_path: PathLike,
         manipulations: List[Manipulation] = None,
@@ -67,6 +68,7 @@ class Manifests:
         """Create Manifests object.
 
         @param name:         Uniquely idenitifes these released manifests.
+        @param model_name:     Charm model name
         @param app_name:     Charm application name which deploys this manifest.
         @param base_path:    path to folder containing manifest files for various
                              releases.
@@ -76,6 +78,7 @@ class Manifests:
         """
 
         self.name = name
+        self.model_name = name
         self.app_name = app_name
         self.base_path = Path(base_path)
         if manipulations is None:

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -78,7 +78,7 @@ class Manifests:
         """
 
         self.name = name
-        self.model_name = name
+        self.model_name = model_name
         self.app_name = app_name
         self.base_path = Path(base_path)
         if manipulations is None:

--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -3,8 +3,8 @@
 """Classes used for mutating or adding to manifests."""
 
 import logging
-from typing import TYPE_CHECKING, Callable, List, Optional
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from lightkube import codecs
 from lightkube.codecs import AnyResource
@@ -149,7 +149,7 @@ class ManifestLabel(Patch):
         if obj.metadata:
             version = self.manifests.current_release
             labels = {
-                "juju.io/application": self.manifests.app_name,
+                "juju.io/application": self.manifests.model.app.name,
                 "juju.io/manifest": self.manifests.name,
                 "juju.io/manifest-version": f"{self.manifests.name}-{version}",
             }

--- a/tests/data/mock_manifests/manifests/v0.2/component-1.yaml
+++ b/tests/data/mock_manifests/manifests/v0.2/component-1.yaml
@@ -15,6 +15,12 @@ stringData:
   test-manifest.conf: |
     I'm secret information
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-manifest-config-map
+  namespace: kube-system
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/tests/metadata.yaml
+++ b/tests/metadata.yaml
@@ -1,0 +1,2 @@
+# Only used by unit testing Harness
+name: unit-testing

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,8 @@ import unittest.mock as mock
 
 import pytest
 from lightkube import ApiError
+from ops.charm import CharmBase
+from ops.testing import Harness
 
 from ops.manifests import Manifests
 
@@ -26,14 +28,21 @@ def api_error_klass():
 
 
 @pytest.fixture
-def manifest():
+def harness():
+    class UnitTestCharm(CharmBase):
+        pass
+
+    yield Harness(UnitTestCharm)
+
+
+@pytest.fixture
+def manifest(harness):
     class TestManifests(Manifests):
         def __init__(self):
             self.data = {}
             super().__init__(
                 "test-manifest",
-                "unit-testing-model",
-                "unit-testing",
+                harness.model,
                 "tests/data/mock_manifests",
             )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,10 +4,13 @@ import unittest.mock as mock
 
 import pytest
 from lightkube import ApiError
+from lightkube.codecs import from_dict
 from ops.charm import CharmBase
 from ops.testing import Harness
 
 from ops.manifests import Manifests
+
+from ops.manifests.manipulations import ManifestLabel, SubtractEq
 
 
 @pytest.fixture(autouse=True)
@@ -37,6 +40,14 @@ def harness():
 
 @pytest.fixture
 def manifest(harness):
+    remove_me = from_dict(
+        dict(
+            apiVersion="v1",
+            kind="ConfigMap",
+            metadata=dict(name="test-manifest-config-map", namespace="kube-system"),
+        )
+    )
+
     class TestManifests(Manifests):
         def __init__(self):
             self.data = {}
@@ -44,6 +55,7 @@ def manifest(harness):
                 "test-manifest",
                 harness.model,
                 "tests/data/mock_manifests",
+                [ManifestLabel(self), SubtractEq(self, remove_me)]
             )
 
         @property

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,6 @@ from ops.charm import CharmBase
 from ops.testing import Harness
 
 from ops.manifests import Manifests
-
 from ops.manifests.manipulations import ManifestLabel, SubtractEq
 
 
@@ -55,7 +54,7 @@ def manifest(harness):
                 "test-manifest",
                 harness.model,
                 "tests/data/mock_manifests",
-                [ManifestLabel(self), SubtractEq(self, remove_me)]
+                [ManifestLabel(self), SubtractEq(self, remove_me)],
             )
 
         @property

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -32,6 +32,7 @@ def manifest():
             self.data = {}
             super().__init__(
                 "test-manifest",
+                "unit-testing-model",
                 "unit-testing",
                 "tests/data/mock_manifests",
             )

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -14,7 +14,7 @@ def test_collector_list_versions(manifest):
     collector = Collector(manifest)
     collector.list_versions(event)
     event.set_results.assert_called_once_with(
-        {"test-manifest versions": "v0.3.1\nv0.2"}
+        {"test-manifest-versions": "v0.3.1\nv0.2"}
     )
 
 
@@ -34,7 +34,7 @@ def test_collector_list_resources_all(manifest):
     collector.list_resources(event, None, None)
     event.set_results.assert_called_once_with(
         {
-            "test-manifest missing": "\n".join(
+            "test-manifest-missing": "\n".join(
                 [
                     "Deployment/kube-system/test-manifest-deployment",
                     "Secret/kube-system/test-manifest-secret",
@@ -50,7 +50,7 @@ def test_collector_list_kind_filter(manifest):
     collector = Collector(manifest)
     collector.list_resources(event, None, "deployment")
     event.set_results.assert_called_once_with(
-        {"test-manifest missing": "Deployment/kube-system/test-manifest-deployment"}
+        {"test-manifest-missing": "Deployment/kube-system/test-manifest-deployment"}
     )
 
 

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -25,13 +25,19 @@ def test_hashable_resource(namespace):
 
 
 def test_manifest():
-    m1 = Manifests("m1", "unit-testing", "tests/data/mock_manifests")
-    m2 = Manifests("m2", "unit-testing", "tests/data/mock_manifests")
+    m1 = Manifests(
+        "m1", "unit-testing-model", "unit-testing", "tests/data/mock_manifests"
+    )
+    m2 = Manifests(
+        "m2", "unit-testing-model", "unit-testing", "tests/data/mock_manifests"
+    )
     assert m1.name != m2.name
 
 
 def test_manifest_without_config():
-    m1 = Manifests("m1", "unit-testing", "tests/data/mock_manifests")
+    m1 = Manifests(
+        "m1", "unit-testing-model", "unit-testing", "tests/data/mock_manifests"
+    )
     with pytest.raises(NotImplementedError):
         _ = m1.config
 

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -25,19 +25,15 @@ def test_hashable_resource(namespace):
 
 
 def test_manifest():
-    m1 = Manifests(
-        "m1", "unit-testing-model", "unit-testing", "tests/data/mock_manifests"
-    )
-    m2 = Manifests(
-        "m2", "unit-testing-model", "unit-testing", "tests/data/mock_manifests"
-    )
+    model = mock.MagicMock(autospec="ops.model.Model")
+    m1 = Manifests("m1", model, "tests/data/mock_manifests")
+    m2 = Manifests("m2", model, "tests/data/mock_manifests")
     assert m1.name != m2.name
 
 
 def test_manifest_without_config():
-    m1 = Manifests(
-        "m1", "unit-testing-model", "unit-testing", "tests/data/mock_manifests"
-    )
+    model = mock.MagicMock(autospec="ops.model.Model")
+    m1 = Manifests("m1", model, "tests/data/mock_manifests")
     with pytest.raises(NotImplementedError):
         _ = m1.config
 

--- a/tests/unit/test_manipulations.py
+++ b/tests/unit/test_manipulations.py
@@ -11,6 +11,7 @@ from ops.manifests import (
     CreateNamespace,
     ManifestLabel,
     update_toleration,
+    SubtractEq,
 )
 
 
@@ -180,3 +181,25 @@ def test_update_deployment_toleration():
         len(obj.spec.template.spec.tolerations) == 1
     ), "The first toleration should be removed"
     assert obj.spec.template.spec.tolerations[0].key == "something.else/unreachable"
+
+
+def test_subtraction_eq(manifest):
+    rsc1 = from_dict(
+        dict(
+            apiVersion="v1",
+            kind="ServiceAccount",
+            metadata=dict(name="test-manifest-manager-1", namespace="kube-system"),
+        )
+    )
+
+    rsc2 = from_dict(
+        dict(
+            apiVersion="v1",
+            kind="ServiceAccount",
+            metadata=dict(name="test-manifest-manager-2", namespace="kube-system"),
+        )
+    )
+
+    adjustment1 = SubtractEq(manifest, rsc1)
+    assert adjustment1(rsc1)
+    assert not adjustment1(rsc2)

--- a/tests/unit/test_manipulations.py
+++ b/tests/unit/test_manipulations.py
@@ -10,8 +10,8 @@ from ops.manifests import (
     ConfigRegistry,
     CreateNamespace,
     ManifestLabel,
-    update_toleration,
     SubtractEq,
+    update_toleration,
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,14 +38,14 @@ deps =
     pytest-html
 commands = pytest \
           -vv \
-          #--cov=ops.manifests \
-	      #--cov-report=term-missing \
-	      #--cov-report=annotate:{[vars]cov_path}/unit/coverage-annotated \
-	      #--cov-report=html:{[vars]cov_path}/unit/coverage-html \
-	      #--cov-report=xml:{[vars]cov_path}/unit/coverage-xml \
+          --cov='{envsitepackagesdir}/ops/manifests' \
+          --cov-report=term-missing \
+          --cov-report=annotate:{[vars]cov_path}/unit/coverage-annotated \
+          --cov-report=html:{[vars]cov_path}/unit/coverage-html \
+          --cov-report=xml:{[vars]cov_path}/unit/coverage-xml \
           --cov-config={toxinidir}/tox.ini \
-	      --html={[vars]cov_path}/unit/tests/index.html \
-	      --junitxml={[vars]cov_path}/unit/junit.xml\
+          --html={[vars]cov_path}/unit/tests/index.html \
+          --junitxml={[vars]cov_path}/unit/junit.xml\
           --tb=native --show-capture=no --log-cli-level=INFO -vs --ignore={[vars]tst_data_path} {posargs:{[vars]tst_path}/unit}
 
 [testenv:integration]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ tst_data_path = {toxinidir}/tests/data/
 all_path = {[vars]ops_path} {[vars]tst_path}
 
 [testenv:lint]
-skipinstall = True
+skip_install = True
 skipsdist = True
 commands =
      flake8 {[vars]all_path}
@@ -22,7 +22,7 @@ deps =
      types-PyYAML
 
 [testenv:format]
-skipinstall = True
+skip_install = True
 skipsdist = True
 description = Apply coding style standards to code
 deps =
@@ -38,11 +38,11 @@ deps =
     pytest-html
 commands = pytest \
           -vv \
-          --cov=ops.manifests \
-	      --cov-report=term-missing \
-	      --cov-report=annotate:{[vars]cov_path}/unit/coverage-annotated \
-	      --cov-report=html:{[vars]cov_path}/unit/coverage-html \
-	      --cov-report=xml:{[vars]cov_path}/unit/coverage-xml \
+          #--cov=ops.manifests \
+	      #--cov-report=term-missing \
+	      #--cov-report=annotate:{[vars]cov_path}/unit/coverage-annotated \
+	      #--cov-report=html:{[vars]cov_path}/unit/coverage-html \
+	      #--cov-report=xml:{[vars]cov_path}/unit/coverage-xml \
           --cov-config={toxinidir}/tox.ini \
 	      --html={[vars]cov_path}/unit/tests/index.html \
 	      --junitxml={[vars]cov_path}/unit/junit.xml\
@@ -59,7 +59,7 @@ deps =
      -e {toxinidir}
 
 [testenv:publish]
-skipinstall = True
+skip_install = True
 skipsdist = True
 deps =
     twine


### PR DESCRIPTION
This PR adds the ability to also remove or filter out resources from being applied using a subtraction manipulation. It adds a SubtractEq manipulation for subtracting resources that are equal to another (equal meaning they have the same name, kind, and namespace).

This can be handy if you have upstream yaml containing resources you actually dont want applied. You can extend the subtraction manipulation as well just like the others for custom filters. 

In addition, it also fixes some bugs regarding the collector actions. The actions were hitting [this error](https://github.com/canonical/operator/blob/de2848146356917c54939b0ba17fb87eeeac6f04/ops/model.py#L1978) due to having dictionary keys with spaces in them. I added tacks instead of the space for the dictionary keys. 

I also added the charm model name in addition to the app name as an attribute of the manifest, as this could be needed along with the app name for certain manipulations, and would not be available in via the charm config