### PR TITLE
Add method for applying missing resources

### DIFF
--- a/ops/manifests/collector.py
+++ b/ops/manifests/collector.py
@@ -69,6 +69,21 @@ class Collector:
                 self.manifests[name].delete_resources(*analysis.extra)
         self._list_resources(event, manifests, resources)
 
+    def apply_missing_resources(
+        self, event, manifests: Optional[str], resources: Optional[str]
+    ):
+        """Applies manifest resources that are missing from the cluster
+
+        Uses the list_resource analysis to determine the missing resources
+        then applies those resources.
+        """
+        results = self._list_resources(event, manifests, resources)
+        for name, analysis in results.items():
+            if analysis.missing:
+                event.log(f"Applying {','.join(str(_) for _ in analysis.missing)}")
+                self.manifests[name].apply_resources(*analysis.missing)
+        self._list_resources(event, manifests, resources)
+
     @property
     def unready(self) -> List[str]:
         """Status of unready resources."""

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -85,6 +85,32 @@ def test_collector_scrub_resources(mock_list_resources, manifest, lk_client):
         type(resource), "delete-me", namespace=None
     )
 
+@mock.patch("ops.manifests.collector.Collector._list_resources")
+def test_collector_install_missing_resources(mock_list_resources, manifest, lk_client, caplog):
+    resource = codecs.from_dict(
+        dict(
+            apiVersion="v1",
+            kind="Namespace",
+            metadata=dict(name="install-me-im-missing"),
+        )
+    )
+    analysis = mock.MagicMock()
+    analysis.missing = {HashableResource(resource)}
+    mock_list_resources.return_value = {"test-manifest": analysis}
+
+    event = mock.MagicMock()
+    collector = Collector(manifest)
+    collector.apply_missing_resources(event, None, None)
+
+    assert mock_list_resources.call_count == 2
+    mock_list_resources.assert_called_with(event, None, None)
+    event.log.assert_called_once_with("Applying Namespace/install-me-im-missing")
+    assert lk_client.apply.call_count == 1
+    assert caplog.messages == [
+        "Applying Namespace/install-me-im-missing",
+        "Applied 1 Resources",
+    ]
+
 
 def test_collector_unready(manifest, lk_client):
     def mock_get_responder(klass, name, namespace=None):

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -85,8 +85,11 @@ def test_collector_scrub_resources(mock_list_resources, manifest, lk_client):
         type(resource), "delete-me", namespace=None
     )
 
+
 @mock.patch("ops.manifests.collector.Collector._list_resources")
-def test_collector_install_missing_resources(mock_list_resources, manifest, lk_client, caplog):
+def test_collector_install_missing_resources(
+    mock_list_resources, manifest, lk_client, caplog
+):
     resource = codecs.from_dict(
         dict(
             apiVersion="v1",


### PR DESCRIPTION
This is very similar to the scrub resources method, but instead of removing extra resources, its applies missing resources that should be present in the cluster according to the manifest, but are not there. 