### PR TITLE
Simple resource matching

### DIFF
--- a/ops/manifests/__init__.py
+++ b/ops/manifests/__init__.py
@@ -7,6 +7,7 @@ from .manipulations import (
     CreateNamespace,
     ManifestLabel,
     Patch,
+    PatchEq,
     SubtractEq,
     update_tolerations,
 )
@@ -20,7 +21,8 @@ __all__ = [
     "ManifestLabel",
     "Manifests",
     "Patch",
-    "update_tolerations",
+    "PatchEq",
+    "update_toleration",
     "SubtractEq",
     "ManifestClientError",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -23,7 +22,7 @@ url = https://github.com/canonical/ops-lib-manifest
 zip_safe = True
 include_package_data = True
 packages = find_namespace:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     backports.cached-property
     ops

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -74,7 +74,7 @@ def manifest(harness):
                 "tests/data/mock_manifests",
                 [
                     ManifestLabel(self),
-                    SubtractEq(self, remove_me),
+                    SubtractEq(remove_me),
                     ConfigRegistry(self),
                 ],
             )

--- a/tests/unit/test_manipulations.py
+++ b/tests/unit/test_manipulations.py
@@ -101,7 +101,7 @@ def test_config_registry_pod_with_init_container():
 
 
 def test_create_namespace(manifest):
-    adjustment = CreateNamespace(manifest, "default")
+    adjustment = CreateNamespace("default")
     obj = adjustment()
     assert obj and obj.metadata, "Should have metadata"
     assert type(obj).__name__ == "Namespace"
@@ -206,6 +206,6 @@ def test_subtraction_eq(manifest):
         )
     )
 
-    adjustment1 = SubtractEq(manifest, rsc1)
+    adjustment1 = SubtractEq(rsc1)
     assert adjustment1(rsc1)
     assert not adjustment1(rsc2)

--- a/tests/unit/test_simple_manipulations.py
+++ b/tests/unit/test_simple_manipulations.py
@@ -1,7 +1,7 @@
 from ops.manifests import ManifestLabel, Manifests, PatchEq, SubtractEq, CreateNamespace
 
 
-def test_add_resource(harness):
+def test_regex_matching(harness):
     class TestManifests(Manifests):
         def __init__(self):
             self.data = {}

--- a/tests/unit/test_simple_manipulations.py
+++ b/tests/unit/test_simple_manipulations.py
@@ -1,0 +1,26 @@
+from ops.manifests import ManifestLabel, Manifests, PatchEq, SubtractEq, CreateNamespace
+
+
+def test_add_resource(harness):
+    class TestManifests(Manifests):
+        def __init__(self):
+            self.data = {}
+            super().__init__(
+                "test-manifest",
+                harness.model,
+                "tests/data/mock_manifests",
+                [
+                    SubtractEq("ConfigMap/kube-system/test-manifest-config-map"),
+                    PatchEq(".*", ManifestLabel(self)),
+                    CreateNamespace("another-ns"),
+                ],
+            )
+
+        @property
+        def config(self):
+            return self.data
+
+    manifest = TestManifests()
+    assert len(manifest.resources) == 4
+    for each in manifest.resources:
+        assert each.resource.metadata and len(each.resource.metadata.labels) == 3

--- a/tests/unit/test_simple_manipulations.py
+++ b/tests/unit/test_simple_manipulations.py
@@ -1,4 +1,4 @@
-from ops.manifests import ManifestLabel, Manifests, PatchEq, SubtractEq, CreateNamespace
+from ops.manifests import CreateNamespace, ManifestLabel, Manifests, PatchEq, SubtractEq
 
 
 def test_regex_matching(harness):

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
      black
      mypy
      types-PyYAML
-     types-backports
+     types-dataclasses
 
 [testenv:format]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,13 @@ tst_data_path = {toxinidir}/tests/data/
 all_path = {[vars]ops_path} {[vars]tst_path}
 
 [testenv:lint]
-skip_install = True
 skipsdist = True
 setenv = 
     MYPYPATH = {[vars]ops_path}
 commands =
      flake8 {[vars]all_path}
      black --check {[vars]all_path}
-     mypy --config-file tox.ini {[vars]ops_path}
+     mypy --config-file tox.ini --check {[vars]all_path}
 deps =
      flake8
      black


### PR DESCRIPTION
makes it easier to define manipulations of resources by string or regex

```python
    class TestManifests(Manifests):
        def __init__(self):
            self.data = {}
            super().__init__(
                "test-manifest",
                model,
                "path/to/data/manifests",
                [
                    SubtractEq("ConfigMap/kube-system/test-manifest-config-map"),
                    PatchEq(".*", ManifestLabel(self)),
                    CreateNamespace("another-ns"),
                ],
            )
```

⚠️ Contains some breaking API changes
😄 Supports python 3.6!