### PR TITLE
Make ConfigRegistry manipulation update initContainer images

### DIFF
--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -166,11 +166,18 @@ class ConfigRegistry(Patch):
         if not registry:
             return
         if obj.kind in ["Pod"]:
-            containers = obj.spec.containers
+            spec = obj.spec
         elif obj.kind in ["DaemonSet", "Deployment", "StatefulSet"]:
-            containers = obj.spec.template.spec.containers
+            spec = obj.spec.template.spec
         else:
-            containers = []
+            spec = None
+
+        containers = []
+        if spec:
+            if spec.containers:
+                containers += spec.containers
+            if spec.initContainers:
+                containers += spec.initContainers
 
         for container in containers:
             full_image = container.image

--- a/tests/unit/test_manipulations.py
+++ b/tests/unit/test_manipulations.py
@@ -82,6 +82,21 @@ def test_config_registry_of_daemonset():
     )
 
 
+def test_config_registry_pod_with_init_container():
+    manifest = mock.MagicMock()
+    rocks = "rocks.canonical.com:443/cdk"
+    manifest.config = {"image-registry": rocks}
+    c1 = dict(name="cool-pod", image="mcr.microsoft.com/awesome/image:1.0")
+    c2 = dict(name="other-pod", image="gcr.io/other/image:2.0")
+    obj = from_dict(dict(apiVersion="v1", kind="Pod", spec=dict(containers=[c1], initContainers=[c2])))
+
+    adjustment = ConfigRegistry(manifest)
+    adjustment(obj)
+
+    assert obj.spec.containers[0].image == f"{rocks}/awesome/image:1.0"
+    assert obj.spec.initContainers[0].image == f"{rocks}/other/image:2.0"
+
+
 def test_create_namespace(manifest):
     adjustment = CreateNamespace(manifest, "default")
     obj = adjustment()

--- a/tests/unit/test_manipulations.py
+++ b/tests/unit/test_manipulations.py
@@ -88,7 +88,11 @@ def test_config_registry_pod_with_init_container():
     manifest.config = {"image-registry": rocks}
     c1 = dict(name="cool-pod", image="mcr.microsoft.com/awesome/image:1.0")
     c2 = dict(name="other-pod", image="gcr.io/other/image:2.0")
-    obj = from_dict(dict(apiVersion="v1", kind="Pod", spec=dict(containers=[c1], initContainers=[c2])))
+    obj = from_dict(
+        dict(
+            apiVersion="v1", kind="Pod", spec=dict(containers=[c1], initContainers=[c2])
+        )
+    )
 
     adjustment = ConfigRegistry(manifest)
     adjustment(obj)


### PR DESCRIPTION
I noticed a recent deploy of Multus from edge stalled with DaemonSet pods in ImagePullBackOff, because the pods had initContainer images that weren't updated to use the correct registry. This should fix it.