### PR TITLE
[API Breaking] Apply appropriate responses to non-api client errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+.. _`changelog`:
+
+=========
+Changelog
+=========
+
+Versions follow `Semantic Versioning <https://semver.org/>`_ (``<major>.<minor>.<patch>``).
+
+Backward incompatible (breaking) changes will only be introduced in major versions
+
+
+ops-lib-manifest 1.0.0 (2022-12-14)
+=========================
+
+Issues Resolved
+* [LP#1999427](https://launchpad.net/bugs/1999427)
+    - handles non-api errors from the client which are represented
+      as an http error response without json content.
+
+Breaking Changes
+----------------
+
+* no longer are `lightkube.core.exceptions.ApiError`s raised on the following methods:
+   * Manifest.status
+   * Manifest.installed_resources
+   * Manifest.apply_manifest
+   * Manifest.delete_manifest
+   * Manifest.apply_resources
+   * Manifest.delete_resources
+
+    instead a more generic exception `ManifestClientError` is raised.

--- a/ops/manifests/__init__.py
+++ b/ops/manifests/__init__.py
@@ -1,4 +1,5 @@
 from .collector import Collector
+from .exceptions import ManifestClientError
 from .manifest import HashableResource, Manifests
 from .manipulations import (
     Addition,
@@ -21,4 +22,5 @@ __all__ = [
     "Patch",
     "update_tolerations",
     "SubtractEq",
+    "ManifestClientError",
 ]

--- a/ops/manifests/exceptions.py
+++ b/ops/manifests/exceptions.py
@@ -1,0 +1,10 @@
+class ManifestBaseError(Exception):
+    """
+    Base Exception for manifest handling.
+    """
+
+
+class ManifestClientError(ManifestBaseError):
+    """
+    Error caused by kubernetes client.
+    """

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -10,14 +10,15 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Dict, FrozenSet, KeysView, List, Optional, Union
 
-import httpx
 import yaml
 from backports.cached_property import cached_property
+from httpx import HTTPStatusError
 from lightkube import Client, codecs
 from lightkube.codecs import AnyResource
 from lightkube.core.exceptions import ApiError
 from ops.model import Model
 
+from .exceptions import ManifestClientError
 from .manipulations import (
     Addition,
     HashableResource,
@@ -209,7 +210,7 @@ class Manifests:
                     obj.name,
                     namespace=obj.namespace,
                 )
-            except (ApiError, httpx.HTTPStatusError):
+            except (ApiError, HTTPStatusError):
                 log.exception(f"Didn't find expected resource installed ({obj})")
                 continue
             result[HashableResource(next_rsc)] = None
@@ -251,16 +252,12 @@ class Manifests:
         """
         for rsc in resources:
             log.info(f"Applying {rsc}")
+            msg = f"Failed Applying {rsc}"
             try:
                 self.client.apply(rsc.resource, force=True)
-            except ApiError:
-                log.exception(f"Failed Applying {rsc}")
-                raise
-            except httpx.HTTPStatusError:
-                # lightkube throws this when the error result isn't
-                # Content-Type == application/json
-                log.exception(f"Failed Applying {rsc}")
-                raise
+            except (ApiError, HTTPStatusError) as ex:
+                log.exception(msg)
+                raise ManifestClientError(msg, ex) from ex
         log.info(f"Applied {len(resources)} Resources")
 
     def delete_resources(
@@ -272,34 +269,23 @@ class Manifests:
     ):
         """Delete specific resources."""
         for obj in resources:
+            log.info(f"Deleting {obj}...")
             try:
                 namespace = obj.namespace or namespace
-                log.info(f"Deleting {obj}")
                 self.client.delete(type(obj.resource), obj.name, namespace=namespace)
-            except ApiError as err:
-                if err.status.message is not None:
-                    err_lower = err.status.message.lower()
-                    if "not found" in err_lower and ignore_not_found:
-                        log.warning(f"Ignoring not found error: {err.status.message}")
-                    elif "(unauthorized)" in err_lower and ignore_unauthorized:
-                        # Ignore error from https://bugs.launchpad.net/juju/+bug/1941655
-                        log.warning(f"Unauthorized error ignored: {err.status.message}")
-                    else:
-                        log.exception(
-                            "ApiError encountered while attempting to delete resource: "
-                            + err.status.message
-                        )
-                        raise
+            except (ApiError, HTTPStatusError) as ex:
+                msg = str(ex)
+                if hasattr(ex, "status") and ex.status.message is not None:
+                    msg = ex.status.message
+                not_found = ignore_not_found and "not found" in msg.lower()
+                unauthed = ignore_unauthorized and "(unauthorized)" in msg.lower()
+                if not_found or unauthed:
+                    log.warning(f"Ignored failed delete of resource: {obj}")
+                    log.warning(msg)
                 else:
-                    log.exception(
-                        "ApiError encountered while attempting to delete resource."
-                    )
-                    raise
-            except httpx.HTTPStatusError:
-                log.exception(
-                    "HTTPError encountered while attempting to delete resource."
-                )
-                raise
+                    log_msg = f"Failed to delete resource: {obj}"
+                    log.exception(f"{log_msg}")
+                    raise ManifestClientError(log_msg) from ex
 
     apply_resource = apply_resources
     delete_resource = delete_resources

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     license="MIT license",
     include_package_data=True,
@@ -23,7 +24,7 @@ setup(
     name="ops.manifest",
     packages=find_namespace_packages(include=['ops.*']),
     url="https://github.com/canonical/ops-lib-manifest",
-    version="0.1.0",
+    version="1.0.0",
     zip_safe=True,
     install_requires=[
         "backports.cached-property",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 import unittest.mock as mock
 
+import httpx
 import pytest
 from lightkube import ApiError
 from lightkube.codecs import from_dict
@@ -27,6 +28,11 @@ def api_error_klass():
             pass
 
     yield TestApiError
+
+
+@pytest.fixture()
+def http_gateway_error():
+    return httpx.HTTPStatusError("502 Bad Gateway", request={}, response={})
 
 
 @pytest.fixture

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -5,6 +5,7 @@ import unittest.mock as mock
 from collections import namedtuple
 
 import pytest
+from lightkube.core.exceptions import ApiError
 
 from ops.manifests import HashableResource, Manifests
 
@@ -138,9 +139,22 @@ def test_apply_manifests(manifest, lk_client, caplog):
     ]
 
 
-def test_apply_failure(manifest, lk_client, api_error_klass, caplog):
+def test_apply_api_error(manifest, lk_client, api_error_klass, caplog):
     lk_client.apply.side_effect = [mock.MagicMock(), api_error_klass]
     with pytest.raises(api_error_klass):
+        manifest.apply_manifests()
+    assert lk_client.apply.call_count == 2
+    assert caplog.messages == [
+        "Applying test-manifest version: v0.2",
+        "Applying ServiceAccount/kube-system/test-manifest-manager",
+        "Applying Secret/kube-system/test-manifest-secret",
+        "Failed Applying Secret/kube-system/test-manifest-secret",
+    ]
+
+
+def test_apply_http_error(manifest, lk_client, http_gateway_error, caplog):
+    lk_client.apply.side_effect = [mock.MagicMock(), http_gateway_error]
+    with pytest.raises(type(http_gateway_error)):
         manifest.apply_manifests()
     assert lk_client.apply.call_count == 2
     assert caplog.messages == [
@@ -164,9 +178,17 @@ def test_installed_resources(manifest, lk_client):
     assert element.kind == "ServiceAccount"
 
 
-def test_installed_resources_fails(manifest, lk_client, api_error_klass):
+def test_installed_resources_api_error(manifest, lk_client, api_error_klass):
     with mock.patch.object(lk_client, "get") as mock_get:
         mock_get.side_effect = api_error_klass
+        rscs = manifest.installed_resources()
+    assert mock_get.call_count == 3
+    assert len(rscs) == 0, "No resources expected to be installed."
+
+
+def test_installed_resources_http_error(manifest, lk_client, http_gateway_error):
+    with mock.patch.object(lk_client, "get") as mock_get:
+        mock_get.side_effect = http_gateway_error
         rscs = manifest.installed_resources()
     assert mock_get.call_count == 3
     assert len(rscs) == 0, "No resources expected to be installed."
@@ -257,7 +279,9 @@ def test_delete_resource_errors(
     ],
     ids=["Unignorable status", "No status message"],
 )
-def test_delete_resource_raised(manifest, api_error_klass, caplog, status, log_format):
+def test_delete_resource_api_error(
+    manifest, api_error_klass, caplog, status, log_format
+):
     rscs = manifest.resources
     element = next(rsc for rsc in rscs if rsc.kind == "Secret")
     api_error_klass.status.message = status
@@ -275,3 +299,25 @@ def test_delete_resource_raised(manifest, api_error_klass, caplog, status, log_f
     )
     assert caplog.messages[0] == "Deleting Secret/kube-system/test-manifest-secret"
     assert caplog.messages[1] == log_format.format(status)
+
+
+def test_delete_resource_http_error(manifest, http_gateway_error, caplog):
+    rscs = manifest.resources
+    element = next(rsc for rsc in rscs if rsc.kind == "Secret")
+
+    with mock.patch.object(
+        manifest, "client", new_callable=mock.PropertyMock
+    ) as mock_client:
+        mock_client.delete.side_effect = http_gateway_error
+        with pytest.raises(type(http_gateway_error)):
+            manifest.delete_resource(
+                element, ignore_unauthorized=True, ignore_not_found=True
+            )
+    mock_client.delete.assert_called_once_with(
+        type(element.resource), "test-manifest-secret", namespace="kube-system"
+    )
+    assert caplog.messages[0] == "Deleting Secret/kube-system/test-manifest-secret"
+    assert (
+        caplog.messages[1]
+        == "HTTPError encountered while attempting to delete resource."
+    )

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -5,7 +5,6 @@ import unittest.mock as mock
 from collections import namedtuple
 
 import pytest
-from lightkube.core.exceptions import ApiError
 
 from ops.manifests import HashableResource, Manifests
 


### PR DESCRIPTION
Lightkube raises `httpx.HTTPStatusError` when the client receives an error that doesn't contain any json content.  Lightkube has determined that in this condition the api-server isn't returning the error per-se -- but perhaps a proxy or load-balancer is in the middle of the transaction between the client and the kube-apiserver

In the event of these types of errors, we likely should report a different log message, but treat both exceptions identically. 

