### PR TITLE
check conditions of custom resources in the cluster

### DIFF
--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -68,7 +68,11 @@ class HashableResource:
         status = getattr(self.resource, "status", None)
         if not status:
             return []
-        return getattr(self.resource.status, "conditions", [])
+        if isinstance(self.resource.status, dict):
+            conditions = self.resource.status.get("conditions", [])
+        else:
+            conditions = getattr(self.resource.status, "conditions", [])
+        return conditions
 
     @property
     def kind(self) -> str:

--- a/tests/data/mock_manifests/manifests/v0.2/component-1.yaml
+++ b/tests/data/mock_manifests/manifests/v0.2/component-1.yaml
@@ -43,3 +43,13 @@ spec:
       containers:
         - name: test-container
           image: gcr.io/google-samples/hello-app:v1.0
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test-manifest-crd
+spec:
+  scope: Namespaced
+  group: ops-lib-manifest.io
+  names: {}
+  versions: []

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -36,6 +36,7 @@ def test_collector_list_resources_all(manifest):
         {
             "test-manifest-missing": "\n".join(
                 [
+                    "CustomResourceDefinition/test-manifest-crd",
                     "Deployment/kube-system/test-manifest-deployment",
                     "Secret/kube-system/test-manifest-secret",
                     "ServiceAccount/kube-system/test-manifest-manager",
@@ -131,5 +132,6 @@ def test_collector_unready(manifest, lk_client):
     with mock.patch.object(lk_client, "get") as mock_get:
         mock_get.side_effect = mock_get_responder
         assert collector.unready == [
+            template.format("CustomResourceDefinition/test-manifest-crd"),
             template.format("Deployment/kube-system/test-manifest-deployment"),
         ]


### PR DESCRIPTION
Include any custom resource defined objects in the status checks if they have `status.conditions`