### PR TITLE
honor JUJU_CHARM_*_PROXY env vars when creating the lightkube client

### DIFF
--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -58,7 +58,7 @@ def _proxied_env():
         "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY"),
         "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY"),
     }
-    os.environ.update({k:v for k,v in proxies.items() if isinstance(v, str)})
+    os.environ.update({k: v for k, v in proxies.items() if isinstance(v, str)})
     try:
         yield
     finally:
@@ -88,7 +88,7 @@ class Manifests:
         name: str,
         model: Model,
         base_path: PathLike,
-        manipulations: List[Manipulation] = None,
+        manipulations: Optional[List[Manipulation]] = None,
     ):
         """Create Manifests object.
 

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from collections import OrderedDict, namedtuple
+from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, FrozenSet, KeysView, List, Optional, Union
@@ -46,6 +47,23 @@ def _by_version(version: str) -> Version:
         return int(part) if part.isdigit() else part
 
     return [convert(c) for c in _VERSION_SPLIT.split(version)]
+
+
+@contextmanager
+def _proxied_env():
+    """Use juju proxy environment variables."""
+    orig = dict(os.environ)
+    proxies = {
+        "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY"),
+        "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY"),
+        "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY"),
+    }
+    os.environ.update({k:v for k,v in proxies.items() if isinstance(v, str)})
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(orig)
 
 
 class Manifests:
@@ -94,7 +112,9 @@ class Manifests:
     @cached_property
     def client(self) -> Client:
         """Lazy evaluation of the lightkube client."""
-        client = Client(field_manager=f"{self.model.app.name}-{self.name}")
+        with _proxied_env():
+            # Construct the client with juju proxy environment vars
+            client = Client(field_manager=f"{self.model.app.name}-{self.name}")
         load_in_cluster_generic_resources(client)
         return client
 

--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -127,8 +127,11 @@ class Addition(Manipulation):
 class Subtraction(Manipulation):
     """Class used to define objects to subtract from the original manifests."""
 
-    def __call__(self, obj: AnyResource) -> bool:
-        """Method called to optionally subtract an object."""
+    def __call__(self, obj: AnyResource) -> bool:  # type: ignore
+        """Method called to optionally subtract an object.
+
+        this is an abstract method, each implementation should return a bool
+        """
         ...
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,15 +11,18 @@ all_path = {[vars]ops_path} {[vars]tst_path}
 [testenv:lint]
 skip_install = True
 skipsdist = True
+setenv = 
+    MYPYPATH = {[vars]ops_path}
 commands =
      flake8 {[vars]all_path}
      black --check {[vars]all_path}
-     -mypy --config-file tox.ini --check {[vars]all_path}
+     mypy --config-file tox.ini {[vars]ops_path}
 deps =
      flake8
      black
      mypy
      types-PyYAML
+     types-backports
 
 [testenv:format]
 skip_install = True
@@ -76,7 +79,13 @@ max-line-length: 88
 
 [mypy]
 
-[mypy-lightkube.core.exceptions]
+[mypy-httpx.*]
+ignore_missing_imports = True
+
+[mypy-lightkube.*]
+ignore_missing_imports = True
+
+[mypy-ops.model]
 ignore_missing_imports = True
 
 [mypy-pytest]


### PR DESCRIPTION
Addresses [LP#2002646](https://bugs.launchpad.net/charm-vsphere-cloud-provider/+bug/2002646) where the lightkube client should use the `JUJU_CHARM_*_PROXY` environment vars