### PR TITLE
remove proxy via juju-charm env vars

### DIFF
--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 from collections import OrderedDict, namedtuple
-from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict, FrozenSet, KeysView, List, Optional, Union
@@ -47,23 +46,6 @@ def _by_version(version: str) -> Version:
         return int(part) if part.isdigit() else part
 
     return [convert(c) for c in _VERSION_SPLIT.split(version)]
-
-
-@contextmanager
-def _proxied_env():
-    """Use juju proxy environment variables."""
-    orig = dict(os.environ)
-    proxies = {
-        "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY"),
-        "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY"),
-        "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY"),
-    }
-    os.environ.update({k: v for k, v in proxies.items() if isinstance(v, str)})
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(orig)
 
 
 class Manifests:
@@ -112,9 +94,8 @@ class Manifests:
     @cached_property
     def client(self) -> Client:
         """Lazy evaluation of the lightkube client."""
-        with _proxied_env():
-            # Construct the client with juju proxy environment vars
-            client = Client(field_manager=f"{self.model.app.name}-{self.name}")
+        # Construct the client with juju proxy environment vars
+        client = Client(field_manager=f"{self.model.app.name}-{self.name}")
         load_in_cluster_generic_resources(client)
         return client
 

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -94,7 +94,6 @@ class Manifests:
     @cached_property
     def client(self) -> Client:
         """Lazy evaluation of the lightkube client."""
-        # Construct the client with juju proxy environment vars
         client = Client(field_manager=f"{self.model.app.name}-{self.name}")
         load_in_cluster_generic_resources(client)
         return client


### PR DESCRIPTION
[LP#2002646](https://bugs.launchpad.net/charm-kubevirt/+bug/2002646)

After trying to use this implementation, it turns out the python `httpx` library suppors `no` proxies as 

> Valid values: a comma-separated list of hostnames/urls

however, often times juju-charm-no-proxy has CIDR ranges in it, and those are not valid/supported by httpx to disable proxy transport.  This will likely direct k8s api requests to the proxy rather than directly from the charm to the api. 

It is best instead to update the charm environment (`juju model-config no-proxy`) to include any api loadbalancers when working within a proxied environment. 

