### PR TITLE
Handle situations where crd resources may have status.conditions

### DIFF
--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -54,6 +54,27 @@ def _unique(collection, key):
             yield item
 
 
+class _ConditionWrap:
+    """Wraps a lightkube condition so it has a status & type properties."""
+
+    def __init__(self, condition):
+        self._condition = condition
+
+    @property
+    def status(self) -> str:
+        """Supports getting the status of a CustomResourceDefinition Resource."""
+        if isinstance(self._condition, dict) and "status" in self._condition:
+            return self._condition["status"]
+        return self._condition.status
+
+    @property
+    def type(self) -> str:
+        """Supports getting the type of a CustomResourceDefinition Resource."""
+        if isinstance(self._condition, dict) and "type" in self._condition:
+            return self._condition["type"]
+        return self._condition.type
+
+
 class HashableResource:
     """Wraps a lightkube resource object so it is hashable."""
 
@@ -72,7 +93,7 @@ class HashableResource:
             conditions = self.resource.status.get("conditions", [])
         else:
             conditions = getattr(self.resource.status, "conditions", [])
-        return conditions
+        return [_ConditionWrap(c) for c in conditions]
 
     @property
     def kind(self) -> str:

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -124,14 +124,19 @@ def test_collector_unready(manifest, lk_client):
         response.metadata.name = name
         response.metadata.namespace = namespace
         if hasattr(response, "status"):
-            response.status.conditions = [Condition("False", "Ready")]
+            response.status.conditions = [
+                Condition("False", "Here"),
+                {"status": "False", "type": "Ready"},
+            ]
         return response
 
     collector = Collector(manifest)
-    template = "test-manifest: {} is not Ready"
+    template = "test-manifest: {} is not {}"
     with mock.patch.object(lk_client, "get") as mock_get:
         mock_get.side_effect = mock_get_responder
         assert collector.unready == [
-            template.format("CustomResourceDefinition/test-manifest-crd"),
-            template.format("Deployment/kube-system/test-manifest-deployment"),
+            template.format("CustomResourceDefinition/test-manifest-crd", "Here"),
+            template.format("CustomResourceDefinition/test-manifest-crd", "Ready"),
+            template.format("Deployment/kube-system/test-manifest-deployment", "Here"),
+            template.format("Deployment/kube-system/test-manifest-deployment", "Ready"),
         ]


### PR DESCRIPTION
CustomResourceDefinitions create objects with specs which may define a `status.conditions` list which conforms to the normal means of indicating status of an object.  

If the resource defined by the CRD is in the charm's manifest, then this library can check the status of those conditions -- but lightkube returns those resources as `dict` rather than fully modeled objects. 

These changes allow for CRD defined resources to have their `status.conditions` checked

here's [the schema](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions#proposal) for conditions
