### PR TITLE
Apply image adjustments to Jobs and CronJobs

### DIFF
--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -209,8 +209,10 @@ class ConfigRegistry(Patch):
             return
         if obj.kind in ["Pod"]:
             spec = obj.spec
-        elif obj.kind in ["DaemonSet", "Deployment", "StatefulSet"]:
+        elif obj.kind in ["DaemonSet", "Deployment", "StatefulSet", "Job"]:
             spec = obj.spec.template.spec
+        elif obj.kind in ["CronJob"]:
+            spec = obj.spec.jobTemplate.spec.template.spec
         else:
             spec = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ops.manifest
-version = 1.0.1
+version = 1.1.0
 author = Adam Dyess
 author_email = adam.dyess@canonical.com
 description = "Kubernetes manifests for Operators"


### PR DESCRIPTION
Jobs and CronJobs can have containers with images that could need to be manipulated by ops-lib-manifest