### PR TITLE
Failed `Manifest.client` should raise errors as ManifestClientError

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,17 +13,21 @@ from ops.manifests import Manifests
 from ops.manifests.manipulations import ConfigRegistry, ManifestLabel, SubtractEq
 
 
+@pytest.fixture
+def mock_load_in_cluster_generic_resources():
+    with mock.patch("ops.manifests.manifest.load_in_cluster_generic_resources") as the_mock:
+        yield the_mock
+
+
 @pytest.fixture(autouse=True)
-def lk_client():
-    with mock.patch(
-        "ops.manifests.manifest.load_in_cluster_generic_resources"
-    ) as mock_load:
-        with mock.patch(
-            "ops.manifests.manifest.Client", autospec=True
-        ) as mock_lightkube:
+def lk_client(request, mock_load_in_cluster_generic_resources):
+    if "ignore_client_autouse" in request.keywords:
+        yield None
+    else:
+        with mock.patch("ops.manifests.manifest.Client", autospec=True) as mock_lightkube:
             yield mock_lightkube.return_value
-        if mock_load.called:
-            mock_load.assert_called_with(mock_lightkube.return_value)
+        if mock_load_in_cluster_generic_resources.called:
+            mock_load_in_cluster_generic_resources.assert_called_with(mock_lightkube.return_value)
 
 
 @pytest.fixture()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,18 +22,13 @@ def mock_load_in_cluster_generic_resources():
 
 
 @pytest.fixture(autouse=True)
-def lk_client(request, mock_load_in_cluster_generic_resources):
-    if "ignore_client_autouse" in request.keywords:
-        yield None
-    else:
-        with mock.patch(
-            "ops.manifests.manifest.Client", autospec=True
-        ) as mock_lightkube:
-            yield mock_lightkube.return_value
-        if mock_load_in_cluster_generic_resources.called:
-            mock_load_in_cluster_generic_resources.assert_called_with(
-                mock_lightkube.return_value
-            )
+def lk_client(mock_load_in_cluster_generic_resources):
+    with mock.patch("ops.manifests.manifest.Client", autospec=True) as mock_lightkube:
+        yield mock_lightkube.return_value
+    if mock_load_in_cluster_generic_resources.called:
+        mock_load_in_cluster_generic_resources.assert_called_with(
+            mock_lightkube.return_value
+        )
 
 
 @pytest.fixture()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,7 +15,9 @@ from ops.manifests.manipulations import ConfigRegistry, ManifestLabel, SubtractE
 
 @pytest.fixture
 def mock_load_in_cluster_generic_resources():
-    with mock.patch("ops.manifests.manifest.load_in_cluster_generic_resources") as the_mock:
+    with mock.patch(
+        "ops.manifests.manifest.load_in_cluster_generic_resources"
+    ) as the_mock:
         yield the_mock
 
 
@@ -24,10 +26,14 @@ def lk_client(request, mock_load_in_cluster_generic_resources):
     if "ignore_client_autouse" in request.keywords:
         yield None
     else:
-        with mock.patch("ops.manifests.manifest.Client", autospec=True) as mock_lightkube:
+        with mock.patch(
+            "ops.manifests.manifest.Client", autospec=True
+        ) as mock_lightkube:
             yield mock_lightkube.return_value
         if mock_load_in_cluster_generic_resources.called:
-            mock_load_in_cluster_generic_resources.assert_called_with(mock_lightkube.return_value)
+            mock_load_in_cluster_generic_resources.assert_called_with(
+                mock_lightkube.return_value
+            )
 
 
 @pytest.fixture()

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -3,8 +3,8 @@
 
 import unittest.mock as mock
 from collections import namedtuple
-import httpx
 
+import httpx
 import pytest
 
 from ops.manifests import HashableResource, ManifestClientError, Manifests
@@ -12,7 +12,9 @@ from ops.manifests import HashableResource, ManifestClientError, Manifests
 
 @pytest.mark.ignore_client_autouse
 def test_fail_load_crds(mock_load_in_cluster_generic_resources):
-    mock_load_in_cluster_generic_resources.side_effect = httpx.ConnectError("SSL: CERTIFICATE_VERIFY_FAILED")
+    mock_load_in_cluster_generic_resources.side_effect = httpx.ConnectError(
+        "SSL: CERTIFICATE_VERIFY_FAILED"
+    )
     model = mock.MagicMock(autospec="ops.model.Model")
     m1 = Manifests("m1", model, "tests/data/mock_manifests")
     with pytest.raises(ManifestClientError):

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -10,7 +10,6 @@ import pytest
 from ops.manifests import HashableResource, ManifestClientError, Manifests
 
 
-@pytest.mark.ignore_client_autouse
 def test_fail_load_crds(mock_load_in_cluster_generic_resources):
     mock_load_in_cluster_generic_resources.side_effect = httpx.ConnectError(
         "SSL: CERTIFICATE_VERIFY_FAILED"

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -3,10 +3,20 @@
 
 import unittest.mock as mock
 from collections import namedtuple
+import httpx
 
 import pytest
 
 from ops.manifests import HashableResource, ManifestClientError, Manifests
+
+
+@pytest.mark.ignore_client_autouse
+def test_fail_load_crds(mock_load_in_cluster_generic_resources):
+    mock_load_in_cluster_generic_resources.side_effect = httpx.ConnectError("SSL: CERTIFICATE_VERIFY_FAILED")
+    model = mock.MagicMock(autospec="ops.model.Model")
+    m1 = Manifests("m1", model, "tests/data/mock_manifests")
+    with pytest.raises(ManifestClientError):
+        m1.client
 
 
 @pytest.mark.parametrize("namespace", [None, "default"])


### PR DESCRIPTION
`HTTPError` is more generic than `HTTPStatusError`

Even errors with the ca certificate can raise `HTTPError`s where as `HTTPStatusErrors` come from a valid connection to the api endpoint, but any response codes from it. 