### PR TITLE
Downed K8s API causes charms to error rather than warn

### DIFF
--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -235,6 +235,11 @@ class Manifests:
                     obj.name,
                     namespace=obj.namespace,
                 )
+            except ManifestClientError:
+                log.exception(
+                    f"Cannot connect to the api endpoint, marking ({obj}) as missing"
+                )
+                continue
             except (ApiError, HTTPError):
                 log.exception(f"Didn't find expected resource installed ({obj})")
                 continue


### PR DESCRIPTION
[LP#2006619] Failing to retrieve the `self.client` can result in a `ManifestClientError` which should be caught and in the case of `installed_resources` look like a missing installed K8s resource rather than an uncaught exception raised by in them charm