### PR TITLE
[LP#2025087] use all the items from a List type manifest

### DIFF
--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -215,7 +215,7 @@ class Manifests:
         content = filepath.read_text()
 
         return [
-            rsc
+            item
             for rsc in yaml.safe_load_all(content)  # load content from file
             if rsc  # ignore empty objects
             for item in (rsc["items"] if rsc["kind"] == "List" else [rsc])

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -212,14 +212,23 @@ class Manifests:
 
         Lightkube can't properly read manifest files which contain List kinds.
         """
-        content = filepath.read_text()
 
-        return [
-            item
-            for rsc in yaml.safe_load_all(content)  # load content from file
-            if rsc  # ignore empty objects
-            for item in (rsc["items"] if rsc["kind"] == "List" else [rsc])
-        ]
+        def _flatten(raw_resources):
+            resources = []
+            for rsc in raw_resources:
+                if not isinstance(rsc, dict):
+                    # found a non-dict item?  Let's log it
+                    log.warning(f"Ignoring non-dictionary resource rsc='{rsc}'")
+                elif rsc.get("kind") == "List":
+                    # found a "List" kind -- lets _flatten all its "items"
+                    resources += _flatten(rsc.get("items", []))
+                else:
+                    # found a non-"List" kind
+                    resources.append(rsc)
+            return resources
+
+        content_list = yaml.safe_load_all(filepath.read_text())
+        return _flatten(content_list)
 
     def status(self) -> FrozenSet[HashableResource]:
         """Returns all installed objects which have a `.status.conditions` attribute."""

--- a/tests/data/mock_manifests/manifests/v0.2/component-3.yaml
+++ b/tests/data/mock_manifests/manifests/v0.2/component-3.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: test-manifest-manager
+    namespace: kube-system
+kind: List
+metadata: {}

--- a/tests/data/mock_manifests/manifests/v0.2/component-3.yaml
+++ b/tests/data/mock_manifests/manifests/v0.2/component-3.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
+kind: List
+metadata: {}
 items:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
     name: test-manifest-manager
     namespace: kube-system
-kind: List
-metadata: {}


### PR DESCRIPTION
[LP#2025087](https://bugs.launchpad.net/ops-lib-manifest/+bug/2025087)

a list generator in `ops.manifest.manifest` under the method `_safe_load` didn't read the items out of an `v1/List` type object which lightkube cannot read by typo.  It doesn't seem any charm has yet needed this but it's starting to fail when developing the `openstack-cloud-controller-manager`