### PR TITLE
Provide fix for checking all conditions for readiness and filtering conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Versions follow `Semantic Versioning <https://semver.org/>`_ (``<major>.<minor>.
 
 Backward incompatible (breaking) changes will only be introduced in major versions
 
+ops-lib-manifest 1.2.0 (2024-02-14)
+=========================
+* [#31](https://github.com/canonical/ops-lib-manifest/issues/31)
+  - The `Collector.conditions` property returns a mapping that ends up
+    hiding information relating to all the conditions of a kubernetes 
+    resource.  Only ONE condition is present in the mapping for each
+    resource. 
+  - Introduce `Collector.all_conditions` property returning a list of
+    conditions and their associated manifests and object
+  - Check unready using the `all_conditions` property
+* Allows a manifest to filter the ready check of each `condition` of an 
+  object that it has installed by overriding the `is_ready(..)` method
+
+
+
+ops-lib-manifest 1.1.4 (2024-01-10)
+=========================
+* only deletes resources created by this charm application
+* LP#2025283 - Audit library to ensure that secrets aren't leaked to logs
+* maintains python 3.7 compatability
+
+
 ops-lib-manifest 1.1.3 (2023-06-28)
 =========================
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ class ExampleApp(Manifests):
         config["release"] = config.pop("example-release", None)
         return config
 
+    def is_ready(self, obj, condition) -> bool:
+        """Filter conditions by object and condition."""
+        if (
+            obj.kind == "Deployment" and
+            obj.name == "MyDeployment" and
+            condition.type == "Ignored"
+        ):
+            return None  # ignore this condition
+        return super().is_ready(obj, condition)
+
 
 class ExampleCharm(CharmBase):
     def __init__(self, *args):

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -25,6 +25,7 @@ from ops.model import Model
 from .exceptions import ManifestClientError
 from .manipulations import (
     Addition,
+    AnyCondition,
     HashableResource,
     ManifestLabel,
     Manipulation,
@@ -250,6 +251,17 @@ class Manifests:
     def status(self) -> FrozenSet[HashableResource]:
         """Returns all installed objects which have a `.status.conditions` attribute."""
         return frozenset(_ for _ in self.installed_resources() if _.status_conditions)
+
+    def is_ready(self, obj: HashableResource, cond: AnyCondition) -> Optional[bool]:
+        """
+        Default Implementation
+        Can be overriden by a manifest object.
+
+        Evaluates True if an object's condition is ready.
+        Evaluates False if an object's condition is not ready.
+        Evaluates None if an object's condition should be ignored.
+        """
+        return cond.status == "True"
 
     def installed_resources(self) -> FrozenSet[HashableResource]:
         """All currently installed resources expected by this manifest."""

--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -74,9 +74,10 @@ class HashableResource:
 
     @property
     def status_conditions(self) -> List[AnyCondition]:
+        conditions: List[AnyCondition] = []
         status = getattr(self.resource, "status", None)
         if not status:
-            return []
+            return conditions
         elif isinstance(self.resource.status, dict):
             conditions = [
                 _

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ops.manifest
-version = 1.1.4
+version = 1.2.0
 author = Adam Dyess
 author_email = adam.dyess@canonical.com
 description = "Kubernetes manifests for Operators"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -86,6 +86,6 @@ def manifest(harness):
         def is_ready(self, obj, cond):
             if obj.kind == "CustomResourceDefinition" and cond.type == "Ignored":
                 return None
-            return cond.status == "True"
+            return super().is_ready(obj, cond)
 
     yield TestManifests()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -83,4 +83,9 @@ def manifest(harness):
         def config(self):
             return self.data
 
+        def is_ready(self, obj, cond):
+            if obj.kind == "CustomResourceDefinition" and cond.type == "Ignored":
+                return None
+            return cond.status == "True"
+
     yield TestManifests()

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -101,7 +101,10 @@ def mock_get_responder(klass, name, namespace=None):
     response.metadata.name = name
     response.metadata.namespace = namespace
     if hasattr(response, "status"):
-        response.status.conditions = [Condition("False", "Ready")]
+        response.status.conditions = [
+            Condition("False", "Ready"),
+            Condition("False", "Error"),
+        ]
     return response
 
 


### PR DESCRIPTION
Addresses [#31](https://github.com/canonical/ops-lib-manifest/issues/31)
  - The `Collector.conditions` property returns a mapping that ends up
    hiding information relating to all the conditions of a kubernetes 
    resource.  Only ONE condition is present in the mapping for each
    resource. 
  - Introduce `Collector.all_conditions` property returning a list of
    conditions and their associated manifests and object
  - Check unready using the `all_conditions` property
Allows a manifest to filter the ready check of each `condition` of an 
  object that it has installed by overriding the `is_ready(..)` method
