### PR TITLE
Update list-resources

### DIFF
--- a/ops/manifests/__init__.py
+++ b/ops/manifests/__init__.py
@@ -1,4 +1,4 @@
-from ops.manifests.collector import Collector
+from ops.manifests.collector import Collector, ResourceAnalysis
 from ops.manifests.exceptions import ManifestClientError
 from ops.manifests.manifest import HashableResource, Manifests
 from ops.manifests.manipulations import (
@@ -17,11 +17,11 @@ __all__ = [
     "ConfigRegistry",
     "CreateNamespace",
     "HashableResource",
+    "ManifestClientError",
     "ManifestLabel",
     "Manifests",
     "Patch",
-    "update_tolerations",
+    "ResourceAnalysis",
     "SubtractEq",
-    "ManifestClientError",
     "update_tolerations",
 ]

--- a/ops/manifests/__init__.py
+++ b/ops/manifests/__init__.py
@@ -1,7 +1,7 @@
-from .collector import Collector
-from .exceptions import ManifestClientError
-from .manifest import HashableResource, Manifests
-from .manipulations import (
+from ops.manifests.collector import Collector
+from ops.manifests.exceptions import ManifestClientError
+from ops.manifests.manifest import HashableResource, Manifests
+from ops.manifests.manipulations import (
     Addition,
     ConfigRegistry,
     CreateNamespace,

--- a/ops/manifests/collector.py
+++ b/ops/manifests/collector.py
@@ -4,7 +4,7 @@
 import logging
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Iterable, List, Mapping, MutableMapping, Optional, Tuple
+from typing import FrozenSet, List, Mapping, MutableMapping, Optional, Tuple
 
 import ops
 
@@ -19,10 +19,10 @@ class ResourceAnalysis:
     """Analysis of resources installed in the cluster."""
 
     manifest: str
-    conflicting: Iterable[HashableResource] = frozenset()
-    correct: Iterable[HashableResource] = frozenset()
-    extra: Iterable[HashableResource] = frozenset()
-    missing: Iterable[HashableResource] = frozenset()
+    conflicting: FrozenSet[HashableResource] = frozenset()
+    correct: FrozenSet[HashableResource] = frozenset()
+    extra: FrozenSet[HashableResource] = frozenset()
+    missing: FrozenSet[HashableResource] = frozenset()
 
 
 class Collector:

--- a/ops/manifests/collector.py
+++ b/ops/manifests/collector.py
@@ -60,13 +60,17 @@ class Collector:
         }
         event.set_results(result)
 
+    def list_resources(self, event, manifests: Optional[str], resources: Optional[str]):
+        """List available, extra, conflicting, and missing resources for each manifest."""
+        self.analyze_resources(event, manifests, resources)
+
     def scrub_resources(self, event, manifests: Optional[str], resources: Optional[str]):
         """Remove extra resources installed by each manifest.
 
         Uses the list_resource analysis to determine the extra resource
         then delete those resources.
         """
-        for analysis in self.list_resources(event, manifests, resources):
+        for analysis in self.analyze_resources(event, manifests, resources):
             if analysis.extra:
                 event.log(f"Removing {','.join(str(_) for _ in analysis.extra)}")
                 self.manifests[analysis.manifest].delete_resources(*analysis.extra)
@@ -78,7 +82,7 @@ class Collector:
         Uses the list_resource analysis to determine the missing resources
         then applies those resources.
         """
-        for analysis in self.list_resources(event, manifests, resources):
+        for analysis in self.analyze_resources(event, manifests, resources):
             if analysis.missing:
                 event.log(f"Applying {','.join(str(_) for _ in analysis.missing)}")
                 self.manifests[analysis.manifest].apply_resources(*analysis.missing)
@@ -136,7 +140,7 @@ class Collector:
             f"{app}={c.current_release}" for app, c in self.manifests.items()
         )
 
-    def list_resources(
+    def analyze_resources(
         self, event: ops.EventBase, manifests: Optional[str], resources: Optional[str]
     ) -> List[ResourceAnalysis]:
         """Analyze resources installed in the cluster.

--- a/ops/manifests/literals.py
+++ b/ops/manifests/literals.py
@@ -1,0 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+APP_LABEL = "juju.io/application"
+MANIFEST_LABEL = "juju.io/manifest"
+MANIFEST_VERSION_LABEL = "juju.io/manifest-version"

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -334,8 +334,9 @@ class Manifests:
         self.apply_resources(*self.resources)
 
     def delete_manifests(self, **kwargs):
-        """Delete all manifests associated with the current release."""
-        self.delete_resources(*self.resources, **kwargs)
+        """Delete all installed manifests associated with the current release."""
+        installed_resources = self.labelled_resources()
+        self.delete_resources(*installed_resources, **kwargs)
 
     def apply_resources(self, *resources: HashableResource):
         """Apply set of resources to the cluster.

--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -21,6 +21,8 @@ from lightkube.generic_resource import GenericGlobalResource, GenericNamespacedR
 from lightkube.models.core_v1 import Toleration
 from lightkube.models.meta_v1 import Time
 
+import ops.manifests.literals as literals
+
 AnyResource = Union[GenericGlobalResource, GenericNamespacedResource]
 
 if TYPE_CHECKING:
@@ -209,9 +211,9 @@ class ManifestLabel(Patch):
         if obj.metadata:
             version = self.manifests.current_release
             labels = {
-                "juju.io/application": self.manifests.model.app.name,
-                "juju.io/manifest": self.manifests.name,
-                "juju.io/manifest-version": f"{self.manifests.name}-{version}",
+                literals.APP_LABEL: self.manifests.model.app.name,
+                literals.MANIFEST_LABEL: self.manifests.name,
+                literals.MANIFEST_VERSION_LABEL: f"{self.manifests.name}-{version}",
             }
             if isinstance(obj, (GenericGlobalResource, GenericNamespacedResource)):
                 # Custom resources in lightkube are built differently

--- a/ops/manifests/manipulations.py
+++ b/ops/manifests/manipulations.py
@@ -110,12 +110,17 @@ class HashableResource:
     @property
     def namespace(self) -> Optional[str]:
         """Return the resource's namespace."""
-        return self.resource.metadata.namespace if self.resource.metadata else None
+        return self.resource.metadata and self.resource.metadata.namespace or None
 
     @property
     def name(self) -> Optional[str]:
         """Return the resource's name."""
-        return self.resource.metadata.name if self.resource.metadata else None
+        return self.resource.metadata and self.resource.metadata.name or None
+
+    @property
+    def labels(self) -> Mapping[str, str]:
+        """Return the resource's labels."""
+        return self.resource.metadata and self.resource.metadata.labels or {}
 
     def __str__(self):
         """String version of the unique parts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ops.manifest"
-version = "1.4.0"
+version = "1.5.0"
 description = "Kubernetes manifests for Operators"
 readme = "README.md"
 requires-python = ">3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ops.manifest"
-version = "1.5.0"
+version = "1.6.0"
 description = "Kubernetes manifests for Operators"
 readme = "README.md"
 requires-python = ">3.8"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -61,7 +61,10 @@ def manifest(harness):
         dict(
             apiVersion="v1",
             kind="ConfigMap",
-            metadata=dict(name="test-manifest-config-map", namespace="kube-system"),
+            metadata=dict(
+                name="test-manifest-config-map",
+                namespace="kube-system",
+            ),
         )
     )
 

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -4,6 +4,7 @@ import unittest.mock as mock
 from collections import namedtuple
 
 import lightkube.codecs as codecs
+from lightkube.resources.storage_v1 import StorageClass
 
 import ops
 from ops.manifests.collector import Collector
@@ -27,25 +28,97 @@ def test_collector_long_version(manifest):
     assert collector.long_version == "Versions: test-manifest=v0.2"
 
 
-def test_collector_list_resources_all(manifest):
+def responder(resp_by_name):
+    def _respond(klass, name, namespace=None):
+        response = resp_by_name.get(name, lambda r: r)
+        obj = mock.MagicMock(spec=klass)
+        obj.kind = klass.__name__
+        obj.metadata.name = name
+        obj.metadata.namespace = namespace
+        return response(obj)
+
+    return _respond
+
+
+def test_collector_list_resources_all(manifest, lk_client, api_error_klass):
+    def label_correct(r):
+        r.metadata.labels = {
+            "juju.io/manifest": manifest.name,
+            "juju.io/application": manifest.model.app.name,
+        }
+        return r
+
+    def label_conflict(r):
+        r.metadata.labels = {
+            "juju.io/manifest": manifest.name,
+            "juju.io/application": manifest.model.app.name + "-conflict",
+        }
+        return r
+
+    def raise_not_found(r):
+        not_found = api_error_klass()
+        not_found.status.code = 404
+        not_found.status.message = f"{r.kind} Not Found"
+        raise not_found
+
+    resp_by_name = {
+        "test-manifest-crd": label_correct,
+        "test-manifest-deployment": label_correct,
+        "test-manifest-secret": raise_not_found,
+        "test-manifest-manager": label_conflict,
+        "test-storage-class": label_correct,
+    }
+    extra_resource = responder(resp_by_name)(StorageClass, "test-storage-class")
+    lk_client.list.return_value = [extra_resource]
+    lk_client.get.side_effect = responder(resp_by_name)
     event = mock.MagicMock(spec=ops.ActionEvent)
     collector = Collector(manifest)
-    collector.list_resources(event, None, None)
+    (analysis,) = collector.list_resources(event, None, None)
     event.set_results.assert_called_once_with(
         {
-            "test-manifest-missing": "\n".join(
+            "test-manifest-correct": "\n".join(
                 [
                     "CustomResourceDefinition/test-manifest-crd",
                     "Deployment/kube-system/test-manifest-deployment",
+                ]
+            ),
+            "test-manifest-extra": "StorageClass/test-storage-class",
+            "test-manifest-missing": "\n".join(
+                [
                     "Secret/kube-system/test-manifest-secret",
                     "ServiceAccount/kube-system/test-manifest-manager",
                 ]
-            )
+            ),
+            "test-manifest-conflicting": "ServiceAccount/kube-system/test-manifest-manager",
         }
     )
 
+    """
+    Note: 
 
-def test_collector_list_kind_filter(manifest):
+    There is a missing ServiceAccount and there is also a conflicting ServiceAccount.
+    The conflicting ServiceAccount is not labeled correctly, so it is not considered part of the manifest.
+
+    This is a different situation from the missing Secret, which is not found at all.
+    """
+    assert analysis.manifest == manifest.name
+    assert len(analysis.conflicting) == 1
+    assert len(analysis.correct) == 2
+    assert len(analysis.missing) == 2
+    assert len(analysis.extra) == 1
+
+
+def test_collector_list_kind_filter(manifest, lk_client, api_error_klass):
+    def raise_not_found(r):
+        not_found = api_error_klass()
+        not_found.status.code = 404
+        not_found.status.message = f"{r.kind} Not Found"
+        raise not_found
+
+    resp_by_name = {
+        "test-manifest-deployment": raise_not_found,
+    }
+    lk_client.get.side_effect = responder(resp_by_name)
     event = mock.MagicMock(spec=ops.ActionEvent)
     collector = Collector(manifest)
     collector.list_resources(event, None, "deployment")
@@ -72,9 +145,9 @@ def test_collector_scrub_resources(mock_list_resources, manifest, lk_client):
             )
         )
     )
-    analysis = mock.MagicMock()
+    analysis = ops.manifests.collector.ResourceAnalysis("test-manifest")
     analysis.extra = {resource}
-    mock_list_resources.return_value = {"test-manifest": analysis}
+    mock_list_resources.return_value = [analysis]
 
     event = mock.MagicMock(spec=ops.ActionEvent)
     collector = Collector(manifest)
@@ -96,9 +169,9 @@ def test_collector_install_missing_resources(mock_list_resources, manifest, lk_c
             metadata=dict(name="install-me-im-missing"),
         )
     )
-    analysis = mock.MagicMock()
+    analysis = ops.manifests.collector.ResourceAnalysis("test-manifest")
     analysis.missing = {HashableResource(resource)}
-    mock_list_resources.return_value = {"test-manifest": analysis}
+    mock_list_resources.return_value = [analysis]
 
     event = mock.MagicMock(spec=ops.ActionEvent)
     collector = Collector(manifest)

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -61,7 +61,7 @@ def test_collector_list_manifest_filter(manifest):
     event.set_results.assert_called_once_with({})
 
 
-@mock.patch("ops.manifests.collector.Collector._list_resources")
+@mock.patch("ops.manifests.collector.Collector.list_resources")
 def test_collector_scrub_resources(mock_list_resources, manifest, lk_client):
     resource = HashableResource(
         codecs.from_dict(
@@ -87,7 +87,7 @@ def test_collector_scrub_resources(mock_list_resources, manifest, lk_client):
     mock_delete.assert_called_once_with(resource, None, False)
 
 
-@mock.patch("ops.manifests.collector.Collector._list_resources")
+@mock.patch("ops.manifests.collector.Collector.list_resources")
 def test_collector_install_missing_resources(mock_list_resources, manifest, lk_client, caplog):
     resource = codecs.from_dict(
         dict(

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -321,12 +321,14 @@ def test_delete_one_resource(manifest, caplog):
 
 
 def test_delete_current_resources(manifest, caplog):
-    with mock.patch.object(manifest, "_delete") as mock_delete:
-        manifest.delete_manifests()
+    rscs = manifest.resources
+    with mock.patch.object(manifest, "labelled_resources") as labelled:
+        labelled.return_value = rscs
+        with mock.patch.object(manifest, "_delete") as mock_delete:
+            manifest.delete_manifests()
     assert len(caplog.messages) == 4, "Should delete the 4 resources in this release"
     assert all(msg.startswith("Deleting") for msg in caplog.messages)
 
-    rscs = manifest.resources
     element = next(rsc for rsc in rscs if rsc.kind == "Secret")
     mock_delete.assert_any_call(element, "kube-system", False)
 


### PR DESCRIPTION
### Overview
* `Collector.list_resources` still returns a `None` value.
* `Collector.analyze_resources` returns an analysis of what is in, out, and conflicting in the cluster

### Details
* return the collected resources from the `Collector` api
* log to the juju-log if the provided event doesn't have a logger (not an ActionEvent)
* Compares the installed resources with the expected resources yielding a report via `list_resources`
* Adjusts the means a charm deletes its resources -- only deleting resources labeled by its own application.