### PR TITLE
fix: delete only resources labeled by ops.manifest

### DIFF
--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -311,7 +311,8 @@ class Manifests:
 
     def delete_manifests(self, **kwargs):
         """Delete all manifests associated with the current release."""
-        self.delete_resources(*self.resources, **kwargs)
+        installed_resources = self.labelled_resources()
+        self.delete_resources(*installed_resources, **kwargs)
 
     def apply_resources(self, *resources: HashableResource):
         """Apply set of resources to the cluster.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ops.manifest"
-version = "1.4.0"
+version = "1.5.0"
 description = "Kubernetes manifests for Operators"
 readme = "README.md"
 requires-python = ">3.8"

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -284,12 +284,14 @@ def test_delete_one_resource(manifest, caplog):
 
 
 def test_delete_current_resources(manifest, caplog):
-    with mock.patch.object(manifest, "_delete") as mock_delete:
-        manifest.delete_manifests()
+    rscs = manifest.resources
+    with mock.patch.object(manifest, "labelled_resources") as labelled:
+        labelled.return_value = rscs
+        with mock.patch.object(manifest, "_delete") as mock_delete:
+            manifest.delete_manifests()
     assert len(caplog.messages) == 4, "Should delete the 4 resources in this release"
     assert all(msg.startswith("Deleting") for msg in caplog.messages)
 
-    rscs = manifest.resources
     element = next(rsc for rsc in rscs if rsc.kind == "Secret")
     mock_delete.assert_any_call(element, "kube-system", False)
 


### PR DESCRIPTION
fix: Only delete resources installed by this charm and manifest
Addresses [LP#2098004](https://bugs.launchpad.net/charm-ceph-csi/+bug/2098004)

### Details
* bumps the version to 1.5.0
* filters the resources to delete by which ones are currently labelled by the charm app and manifest
