### PR TITLE
Raise a `ManifestReleaseError` if a release version doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versions follow `Semantic Versioning <https://semver.org/>`_ (``<major>.<minor>.
 
 Backward incompatible (breaking) changes will only be introduced in major versions
 
+ops-lib-manifest 1.7.0 (2025-05-21)
+=========================
+* Allows for `Manifests` to check the specified revision exists as a given
+  version
+
 ops-lib-manifest 1.3.0 (2024-02-14)
 =========================
 * Allows an Addition object to create an iterable of Resources, not just
@@ -17,13 +22,13 @@ ops-lib-manifest 1.2.0 (2024-02-14)
 =========================
 * [#31](https://github.com/canonical/ops-lib-manifest/issues/31)
   - The `Collector.conditions` property returns a mapping that ends up
-    hiding information relating to all the conditions of a kubernetes 
+    hiding information relating to all the conditions of a kubernetes
     resource.  Only ONE condition is present in the mapping for each
-    resource. 
+    resource.
   - Introduce `Collector.all_conditions` property returning a list of
     conditions and their associated manifests and object
   - Check unready using the `all_conditions` property
-* Allows a manifest to filter the ready check of each `condition` of an 
+* Allows a manifest to filter the ready check of each `condition` of an
   object that it has installed by overriding the `is_ready(..)` method
 
 
@@ -39,7 +44,7 @@ ops-lib-manifest 1.1.3 (2023-06-28)
 
 Issues Resolved
 * [LP#2025087](https://launchpad.net/bugs/2025087)
-   - resolves issue where every item from a List 
+   - resolves issue where every item from a List
      type resource object is read from the list
 
 ops-lib-manifest 1.1.2 (2023-04-17)

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ its content, and deploy those manifests when any of the **configurable** data is
 
 ## Supporting Multiple Releases
 Likewise, the projects which release reference manifest files, will also release versions
-of manifests. It's possible for a charm to load all the supported manifest files into a 
-folder structure such the charm supports multiple releases. This library supports this 
-requirements by having the charm store upstream manifest files unchanged in a folder 
+of manifests. It's possible for a charm to load all the supported manifest files into a
+folder structure such the charm supports multiple releases. This library supports this
+requirements by having the charm store upstream manifest files unchanged in a folder
 structure like this:
 
 ```
@@ -63,7 +63,7 @@ Key file-heirarchy requirements
 ## Sample Usage
 
 Once your charm includes the above manifest file hierarchy, your charm will need to define the
-mutations the library should make to the manifests. 
+mutations the library should make to the manifests.
 
 ```python
 from ops.manifests import Collector, Manifests, ManifestLabel, ConfigRegistry
@@ -110,10 +110,10 @@ class ExampleCharm(CharmBase):
 
         # Register actions callbacks
         self.framework.observe(self.on.list_versions_action, self._list_versions)
-        
+
         # Register update status callbacks
         self.framework.observe(self.on.update_status, self._update_status)
-    
+
     def _list_versions(self, event):
         self.collector.list_versions(event)
 
@@ -125,7 +125,7 @@ class ExampleCharm(CharmBase):
             self.unit.status = ActiveStatus("Ready")
             self.unit.set_workload_version(self.collector.short_version)
             self.app.status = ActiveStatus(self.collector.long_version)
-        
+
 ```
 
 ## Manifests
@@ -137,11 +137,12 @@ This class provides the following functions:
 4) Manipulates resource objects of a specific release
 5) Provides comparisons between the installed resources and expected resources
 6) Provides user listing of available releases
+7) Provides a means of checking if the selected manifest release exists
 
 ### Creating a Manifest Impl
 It's expected that the developer create a `Manifest` impl -- a derived class -- that implements
 one property -- `config`.  This property provides some basic requirements to the
-Manifest parent class and gives context for each custom `Manipulation` to act on 
+Manifest parent class and gives context for each custom `Manipulation` to act on
 relation or config data.
 
 ```python
@@ -151,10 +152,21 @@ relation or config data.
 ```
 
 #### Expected `config` key mappings
-* `release` 
+* `release`
     * optional `str` which identifies which release of the manifest to choose.
-    * defaults to `None` which will select the `default_release` if available.
-    * if `default_release` isn't found, the latest release is chosen.
+    * when `self._check_release = False`, legacy behavior for selecting a
+      release will engage:
+        * use the configured release if set
+        * if unset, the `default_release` is chosen.
+        * if `default_release` is unset, the `latest_release` is chosen.
+        * if `latest_release` is unset, the `""` release is chosen.
+    * when `self._check_release = True`, a `ManifestReleaseError` exception
+      is raised under the follow conditions:
+        * a `configured` release is chosen that isn't among the available releases
+        * a `default_release` is chosen that isn't among the available releases
+        * a `latest_release` is chosen that isn't among the available releases
+        * `configured`, `default_release`, and `latest_release` are all empty
+
 * `image-registry`
     * optional `str` which will be used by the `ConfigRegistry` manipulation
     * defaults to `None` which uses the resources built-in registry location
@@ -162,16 +174,16 @@ relation or config data.
 
 
 ### Cluster CRUD methods
-* `status()` 
+* `status()`
     * queries all in cluster resources associated with the current release which
       has a `.status.conditions` attribute.
 * `installed_resources()`
-    * queries all in cluster resources associated with the current release which 
+    * queries all in cluster resources associated with the current release which
       is installed.
 * `labelled_resources()`
     * queries all in cluster resources associated with the charm and manifest in general
       which is installed.
-    * this can be compared with the `resources` property to look for extra resources 
+    * this can be compared with the `resources` property to look for extra resources
       installed which are no longer necessary.
 * `apply_manifests()`
     * applies all resources from the current release into the cluster.
@@ -183,7 +195,7 @@ relation or config data.
     * will delete all current release resources from the cluster
     * see `delete_resources` for keyword arguments
 * `delete_resources(...)`
-    * delete a specified set of resources from the cluster with options to 
+    * delete a specified set of resources from the cluster with options to
       seamlessly handle certain failures.
 * `delete_resource(...)`
     * alias to `delete_resources` for when reading clarity demands only deleting
@@ -192,7 +204,7 @@ relation or config data.
 ## Collector
 
 This class provides a native collection for operating collectively on
-the manifests within a single charm.  It provides methods for responding to 
+the manifests within a single charm.  It provides methods for responding to
 * action list-versions
 * action scrub-resources
 * action list-resources
@@ -200,8 +212,8 @@ the manifests within a single charm.  It provides methods for responding to
 * querying the collective versions (short and long types)
 * listing which resources have a non-active status
 
-To integrate into an [ops charm](https://juju.is/docs/sdk/ops), for each 
-released application the charm manages, create a new `Manifests` impl, 
+To integrate into an [ops charm](https://juju.is/docs/sdk/ops), for each
+released application the charm manages, create a new `Manifests` impl,
 and add an instance of it to a `Collector`.
 
 ```python
@@ -229,7 +241,7 @@ class ExampleCharm(CharmBase):
         ...
         # collection of ManifestImpls
         self.collector = Collector(
-            ExampleApp(self, self.config), 
+            ExampleApp(self, self.config),
             AlternateApp(self, self.config),
         )
 ```
@@ -241,7 +253,7 @@ class ExampleCharm(CharmBase):
 Some resources already exist within the manifest, and just need to be updated.
 
 #### Built in Patchers
-* `ManifestLabel` 
+* `ManifestLabel`
   * adds to each resource's `metadata.labels` the following:
      1) `juju.io/application: manifests.app_name`
      2) `juju.io/manifest: manifests.name`
@@ -254,7 +266,7 @@ Some resources already exist within the manifest, and just need to be updated.
   * If the charm doesn't wish to alter the config, ensure nothing exists
     in the `image-registry`.
 
-* `update_toleration` 
+* `update_toleration`
   * not officially a patcher, but can be used by a custom Patcher
     to adjust tolerations on `Pod`, `DaemonSet`, `Deployment`, and `StatefulSet`
     resources.
@@ -264,15 +276,15 @@ Some resources do not exist in the release manifest and must be added. The `Addi
 before the rest of the `Patch` manipulations are applied.
 
 #### Built in Adders
-* `CreateNamespace` - Creates a namespace resource using either the manifest's default namespace or 
-                      an argument passed in to the constructor of this class. 
+* `CreateNamespace` - Creates a namespace resource using either the manifest's default namespace or
+                      an argument passed in to the constructor of this class.
 
 ### Subtracting a manifest resource
 Some manifest resources are not needed and must be removed. The `Subtraction` manipulations are added
 before the rest of the `Patch` manipulations are applied.
 
 #### Built in Subtractors
-* `SubtractEq` - Subtracts a manifest resource equal to the resource passed in as an argument. Resources are considered 
+* `SubtractEq` - Subtracts a manifest resource equal to the resource passed in as an argument. Resources are considered
                  equal if they have the same kind, name, and namespace.
 
 ### Custom Manipulations

--- a/ops/manifests/__init__.py
+++ b/ops/manifests/__init__.py
@@ -1,5 +1,5 @@
 from ops.manifests.collector import Collector, ResourceAnalysis
-from ops.manifests.exceptions import ManifestClientError
+from ops.manifests.exceptions import ManifestClientError, ManifestReleaseError
 from ops.manifests.manifest import HashableResource, Manifests
 from ops.manifests.manipulations import (
     Addition,
@@ -18,6 +18,7 @@ __all__ = [
     "CreateNamespace",
     "HashableResource",
     "ManifestClientError",
+    "ManifestReleaseError",
     "ManifestLabel",
     "Manifests",
     "Patch",

--- a/ops/manifests/exceptions.py
+++ b/ops/manifests/exceptions.py
@@ -8,3 +8,9 @@ class ManifestClientError(ManifestBaseError):
     """
     Error caused by kubernetes client.
     """
+
+
+class ManifestReleaseError(ManifestBaseError):
+    """
+    Error caused by an invalid release.
+    """

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -162,38 +162,26 @@ class Manifests:
 
         # Determine what the user has configured (it could be undefined or empty)
         config_release: str = self.config.get("release") or ""
-
-        if self._check_release:
-            if config_release:
-                if config_release not in self.releases:
-                    raise ManifestReleaseError(
-                        f"Configured release for {self.name} '{config_release}' not among {self.releases}"
-                    )
-                log.debug(
-                    f"Configured release for {self.name} '{config_release}' is among {self.releases}"
-                )
-            elif self.default_release:
-                if self.default_release not in self.releases:
-                    raise ManifestReleaseError(
-                        f"Default release for {self.name} '{self.default_release}' not among {self.releases}"
-                    )
-                log.debug(
-                    f"Default release for {self.name} '{self.default_release}' is among {self.releases}"
-                )
-            elif self.latest_release:
-                if self.latest_release not in self.releases:
-                    raise ManifestReleaseError(
-                        f"Latest release for {self.name} '{self.latest_release}' not among {self.releases}"
-                    )
-                log.debug(
-                    f"Latest release for {self.name} '{self.latest_release}' is among {self.releases}"
-                )
-            else:
-                raise ManifestReleaseError(
-                    f"No release selected for {self.name} among {self.releases}"
-                )
-
-        return config_release or self.default_release or self.latest_release
+        if not self._check_release:
+            return config_release or self.default_release or self.latest_release
+        elif config_release:
+            candidate, source = config_release, "Configured"
+        elif self.default_release:
+            candidate, source = self.default_release, "Default"
+        elif self.latest_release:
+            candidate, source = self.latest_release, "Latest"
+        else:
+            raise ManifestReleaseError(
+                f"No release selected for {self.name} among {self.releases}"
+            )
+        if candidate not in self.releases:
+            raise ManifestReleaseError(
+                f"{source} release for {self.name} '{candidate}' not among {self.releases}"
+            )
+        log.debug(
+            "%s release for %s '%s'. (Available %s)", source, self.name, candidate, self.releases
+        )
+        return candidate
 
     @property
     def resources(self) -> KeysView[HashableResource]:

--- a/ops/manifests/manifest.py
+++ b/ops/manifests/manifest.py
@@ -9,6 +9,7 @@ from collections import OrderedDict, namedtuple
 from functools import cached_property, lru_cache
 from pathlib import Path
 from typing import (
+    Any,
     Dict,
     FrozenSet,
     Iterator,
@@ -30,10 +31,10 @@ from lightkube.generic_resource import (
     load_in_cluster_generic_resources,
 )
 
+import ops
 import ops.manifests.literals as literals
-from ops.model import Model
 
-from .exceptions import ManifestClientError
+from .exceptions import ManifestClientError, ManifestReleaseError
 from .manipulations import (
     Addition,
     AnyCondition,
@@ -80,24 +81,27 @@ class Manifests:
     def __init__(
         self,
         name: str,
-        model: Model,
+        model: ops.Model,
         base_path: PathLike,
         manipulations: Optional[List[Manipulation]] = None,
+        check_release: bool = False,
     ):
         """Create Manifests object.
 
-        @param name:         Uniquely idenitifes these released manifests.
-        @param model:        ops framework Model
-        @param base_path:    path to folder containing manifest files for various
-                             releases.
-        @param manipulations list of manipulation objects which will alter the existing
-                             resources in the manifest files.
-                             ~ defaults to updating the label ~
+        @param name:          Uniquely identifies these released manifests.
+        @param model:         ops framework Model
+        @param base_path:     path to folder containing manifest files for various
+                              releases.
+        @param manipulations: list of manipulation objects which will alter the existing
+                              resources in the manifest files.
+                              ~ defaults to updating the label ~
+        @param check_release: if True, will check if the current release is available
         """
 
         self.name = name
         self.base_path = Path(base_path)
         self.model = model
+        self._check_release = check_release
         if manipulations is None:
             self.manipulations: List[Manipulation] = [ManifestLabel(self)]
         else:
@@ -116,7 +120,7 @@ class Manifests:
         return client
 
     @property
-    def config(self) -> Dict:
+    def config(self) -> Dict[str, Any]:
         """Retrieve the current available config to use during manifest building."""
         raise NotImplementedError
 
@@ -150,12 +154,46 @@ class Manifests:
     @cached_property
     def latest_release(self) -> str:
         """Lookup the default release suggested by the manifest."""
-        return self.releases[0]
+        return self.releases[0] if self.releases else ""
 
     @property
     def current_release(self) -> str:
-        """Determine the current release from charm config."""
-        return self.config.get("release") or self.default_release or self.latest_release
+        """Determine the current release from charm config and available releases."""
+
+        # Determine what the user has configured (it could be undefined or empty)
+        config_release: str = self.config.get("release") or ""
+
+        if self._check_release:
+            if config_release:
+                if config_release not in self.releases:
+                    raise ManifestReleaseError(
+                        f"Configured release for {self.name} '{config_release}' not among {self.releases}"
+                    )
+                log.debug(
+                    f"Configured release for {self.name} '{config_release}' is among {self.releases}"
+                )
+            elif self.default_release:
+                if self.default_release not in self.releases:
+                    raise ManifestReleaseError(
+                        f"Default release for {self.name} '{self.default_release}' not among {self.releases}"
+                    )
+                log.debug(
+                    f"Default release for {self.name} '{self.default_release}' is among {self.releases}"
+                )
+            elif self.latest_release:
+                if self.latest_release not in self.releases:
+                    raise ManifestReleaseError(
+                        f"Latest release for {self.name} '{self.latest_release}' not among {self.releases}"
+                    )
+                log.debug(
+                    f"Latest release for {self.name} '{self.latest_release}' is among {self.releases}"
+                )
+            else:
+                raise ManifestReleaseError(
+                    f"No release selected for {self.name} among {self.releases}"
+                )
+
+        return config_release or self.default_release or self.latest_release
 
     @property
     def resources(self) -> KeysView[HashableResource]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ops.manifest"
-version = "1.6.0"
+version = "1.7.0"
 description = "Kubernetes manifests for Operators"
 readme = "README.md"
 requires-python = ">3.8"
@@ -52,4 +52,3 @@ zip-safe = true
 
 [tool.setuptools.packages.find]
 namespaces = true
-

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -80,6 +80,7 @@ def manifest(harness):
                     SubtractEq(self, remove_me),
                     ConfigRegistry(self),
                 ],
+                check_release=True,
             )
 
         @property

--- a/tests/unit/test_manifests.py
+++ b/tests/unit/test_manifests.py
@@ -10,7 +10,7 @@ from tempfile import NamedTemporaryFile
 import httpx
 import pytest
 
-from ops.manifests import HashableResource, ManifestClientError, Manifests
+from ops.manifests import HashableResource, ManifestClientError, ManifestReleaseError, Manifests
 
 
 def test_fail_load_crds(mock_load_in_cluster_generic_resources):
@@ -60,20 +60,48 @@ def test_releases(manifest):
     assert manifest.releases == ["v0.3.1", "v0.2"]
 
 
-def test_current_release(manifest):
+@pytest.mark.parametrize(
+    "title, config, default, latest",
+    [
+        ("Configured", "v0.1", "", ""),
+        ("Default", "", "v0.1", ""),
+        ("Latest", "", "", "v0.1"),
+        ("Unconfigured", "", "", ""),
+    ],
+    ids=["Configured=v0.1", "Default=v0.1", "Latest=v0.1", "Unconfigured"],
+)
+def test_current_release_doesnt_exist(manifest, title, config, default, latest):
+    # Set the release to a non-existent version
+    manifest.data["release"] = config
+
+    with mock.patch.object(
+        manifest, "default_release", new_callable=mock.PropertyMock(return_value=default)
+    ), mock.patch.object(
+        manifest, "latest_release", new_callable=mock.PropertyMock(return_value=latest)
+    ):
+        with pytest.raises(ManifestReleaseError) as ie:
+            manifest.current_release
+    if title == "Unconfigured":
+        assert str(ie.value) == f"No release selected for test-manifest among {manifest.releases}"
+    else:
+        assert (
+            str(ie.value)
+            == f"{title} release for test-manifest 'v0.1' not among {manifest.releases}"
+        )
+
+
+def test_current_release(manifest, caplog):
     manifest.data["release"] = None
     assert manifest.current_release == "v0.2"  # as defined by tests/data/mock_manifests/version
 
-    manifest.data["release"] = "v0.1"
-    assert manifest.current_release == "v0.1"  # as defined by config
-
+    manifest.data["release"] = None
     with mock.patch.object(
         manifest, "default_release", new_callable=mock.PropertyMock(return_value=None)
     ):
-        manifest.default_release == "v0.3.1"  # absence of a default_release
+        assert manifest.current_release == "v0.3.1"  # absence of a default_release
 
 
-@pytest.mark.parametrize("release, uniqs", [("v0.1", 0), ("v0.2", 4), ("v0.3.1", 1)])
+@pytest.mark.parametrize("release, uniqs", [("v0.2", 4), ("v0.3.1", 1)])
 def test_resources_version(manifest, release, uniqs):
     manifest.data["release"] = release
     rscs = manifest.resources
@@ -406,7 +434,7 @@ def tmp_manifests(tmp_path):
 
 def test_non_dictionary_resource(tmp_manifests, caplog):
     caplog.set_level(logging.WARNING)
-    path = tmp_manifests.base_path / "manifests" / tmp_manifests.current_release
+    path = tmp_manifests.base_path / "manifests" / tmp_manifests.config["release"]
     with NamedTemporaryFile(mode="w+t", dir=path, suffix=".yaml") as fp:
         fp.write("non-yaml")
         fp.flush()
@@ -416,7 +444,7 @@ def test_non_dictionary_resource(tmp_manifests, caplog):
 
 def test_non_kubernetes_resource(tmp_manifests, caplog):
     caplog.set_level(logging.WARNING)
-    path = tmp_manifests.base_path / "manifests" / tmp_manifests.current_release
+    path = tmp_manifests.base_path / "manifests" / tmp_manifests.config["release"]
     with NamedTemporaryFile(mode="w+t", dir=path, suffix=".yaml") as fp:
         fp.write("kind: Missing apiVersion")
         fp.flush()
@@ -427,7 +455,7 @@ def test_non_kubernetes_resource(tmp_manifests, caplog):
 
 def test_nested_kubernetes_resource(tmp_manifests, caplog):
     caplog.set_level(logging.WARNING)
-    path = tmp_manifests.base_path / "manifests" / tmp_manifests.current_release
+    path = tmp_manifests.base_path / "manifests" / tmp_manifests.config["release"]
     with NamedTemporaryFile(mode="w+t", dir=path, suffix=".yaml") as fp:
         fp.write(
             """---


### PR DESCRIPTION
Supports a new feature flag for `Manifests` to allow for checking if the chosen release version exists.  Use of that feature flag will raise a new exception in the event a manifest release isn't available in the charm.